### PR TITLE
Restructured and edited contribution guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ If you followed the formatting guidelines above, you're now ready to start editi
 
 ### Python Packaging Scripts
 
-Your `setup.py` file should contain all of the appropriate metadata and dependencies required to build your package. Use the sample `setup.py` file in this repository as a starting point for your own project.
+Your `setup.py` file should contain all of the appropriate metadata and dependencies required to build your package. Use the [sample `setup.py` file](https://github.com/astronomer/airflow-provider-sample/blob/main/setup.py) in this repository as a starting point for your own project.
 
 If some of the options for building your package are variables or user-defined, you can specify a `setup.cfg` file instead.
 

--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@ Provider repositories must be public on Github and follow the structural and tec
 
 Here, you'll find information on requirements and best practices for key aspects of your project:
 
-- [File formatting](#part-1-formatting-standards)
-- [Development](#part-2-development-standards)
-- [Airflow integration](#part-3-airflow-integration-standards)
-- [Documentation](#part-4-documentation-standards)
-- [Testing](#part-5-functional-testing)
+- File formatting
+- Development
+- Airflow integration
+- Documentation
+- Testing
 
 ## Part 1: Formatting Standards
 

--- a/README.md
+++ b/README.md
@@ -7,25 +7,30 @@
   Airflow Sample Provider
 </h1>
   <h3 align="center">
-  Guildelines on building, deploying, and maintaining provider packages that will help Airflow users interface with external systems. Maintained with ❤️ by Astronomer.
+  Guidelines on building, deploying, and maintaining provider packages that will help Airflow users interface with external systems. Maintained with ❤️ by Astronomer.
 </h3>
 
 <br/>
 
-This repository demonstrates best practices for building, structuring, and deploying Airflow provider packages as independent python modules available on PyPI.
+This repository provides best practices for building, structuring, and deploying Airflow provider packages as independent python modules available on PyPI.
 
-## Requirements
+Provider repositories must be public on Github and follow the structural and technical guidelines laid out in this Readme. Ensure that all of these requirements have been met before submitting a provider package for community review.
 
-Provider repositories must be public on Github and follow the structural and technical guidelines laid out in this Readme.
+## Part 1: Formatting Standards
 
-The package should be named as follows:
+Before writing and testing the functionality of your provider package, ensure that your project follows these formatting conventions.
+
+### Package name
+
+The highest level directory in the provider package should be named in the following format:
 
 ```
 airflow-provider-<provider-name>
 ```
-## Repository Structure
 
-You'll need this package structure to construct a provider package repo:
+### Repository structure
+
+All provider packages must adhere to the following file structure:
 
 ```bash
 ├── LICENSE # A license is required, MIT or Apache is preferred.
@@ -59,60 +64,55 @@ You'll need this package structure to construct a provider package repo:
 ```
 
 
-## Development Standards
+## Part 2: Development Standards
 
-### Building Provider Package
+If you followed the formatting guidelines above, you're now ready to start editing files to include standard package functionality.
 
-Most of what you need is included in `setup.py` and ready to customize. You may use `setup.cfg` as a valid alternative.
+### Python Packaging Scripts
 
-### Provider Readmes
+Your `setup.py` file should contain all of the appropriate metadata and dependencies required to build your package. Use the sample `setup.py` file in this repository as a starting point for your own project.
 
-Readmes should contain top-level documentation about the provider's service, how to build a connection to the service from Airflow, what modules exist within the package, what dependency versions the provider has been tested with, and how the repository maintainers would like folks to contribute.
+If some of the options for building your package are variables or user-defined, you can specify a `setup.cfg` file instead.
 
-#### Managing Dependencies
+### Managing Dependencies
 
-When building providers, these guidelines will help you avoid potential for dependency conflicts.
+When building providers, these guidelines will help you avoid potential for dependency conflicts:
 
-1. It is important that the providers do not include dependencies that conflict with the underlying dependencies for a particular Airflow version. [All of the default dependencies included in the core Airflow project can be found here.](https://github.com/apache/airflow/blob/master/setup.py#L705)
-2. Keep all dependencies upper-bound relaxed; at least allow minor versions, ie. `depx >=2.0.0, <3`. Please include a section in your Readme with the exact set of dependencies that your provider package has been tested with.
+- It is important that the providers do not include dependencies that conflict with the underlying dependencies for a particular Airflow version. All of the default dependencies included in the core Airflow project can be found in the Airflow [setup.py file](https://github.com/apache/airflow/blob/master/setup.py#L705).
+- Keep all dependencies relaxed at the upper bound. At the lower bound, specify minor versions (for example, `depx >=2.0.0, <3`).
 
-#### Versioning
+### Versioning
 
-Maintainers should use standard semantic versioning for releasing their packages. They should be sure to update all of the relevant metadata fields before cutting a new release.
+Use standard semantic versioning for releasing your package. When cutting a new release, be sure to update all of the relevant metadata fields in your setup file.
 
 ### Building Modules
 
-All modules should follow a specific set of best practices that optimize for how they will run in the context of Airflow.
-- **All classes should run without access to the internet.** The Airflow scheduler parses DAGs on a regular schedule. Every time that parse happens, Airflow will execute whatever is contained in the `init` method of your class. If that `init` method contains network requests, such as calls to a third party API, there will be problems due to repeated network calls.
-- **Init methods should not call functions which only return valid objects at runtime**. This will cause a fatal import error when trying to import a module into a DAG. A common pattern to reference connectors and variables within DAGs is to use [Jinja Templating](https://airflow.apache.org/docs/apache-airflow/stable/concepts.html#jinja-templating).
-- **All operator modules will need an `execute` method.** This method defines the logic that the operator will implement.
+All modules must follow a specific set of best practices to optimize their performance with Airflow:
+
+- **All classes should always be able to run without access to the internet.** The Airflow Scheduler parses DAGs on a regular schedule. Every time that parse happens, Airflow will execute whatever is contained in the `init` method of your class. If that `init` method contains network requests, such as calls to a third party API, there will be problems due to repeated network calls.
+- **Init methods should never call functions which return valid objects only at runtime**. This will cause a fatal import error when trying to import a module into a DAG. A common best practice for referencing connectors and variables within DAGs is to use [Jinja Templating](https://airflow.apache.org/docs/apache-airflow/stable/concepts.html#jinja-templating).
+- **All operator modules need an `execute` method.** This method defines the logic that the operator will implement.
 
 Modules should also take advantage of native Airflow features that allow your provider to:
-- Register custom conn types for a great UX around connecting to your tool.
-- Include `extra-links` that link your provider back to its page on the Astronomer Registry for easy user access to documentation and example DAGs.
 
-See the `Airflow Integration` section below for more information on how to build for these extra features.
+- Register custom connection types, which improve the user experience when connecting to your tool.
+- Include `extra-links` that link your provider back to its page on the Astronomer Registry. This provides users easy access to documentation and example DAGs.
 
-### Testing Modules
+See the `Airflow Integration` section below for more information on how to build in these extra features.
 
-The provider should contain a top-level `tests/` folder that contains unit tests for all modules that exist in the repository. Maintainers may write tests in the framework of their choice- the Astronomer team and Airflow community typically uses [pytest](https://docs.pytest.org/en/stable/).
+### Unit testing
+
+Your top-level `tests/` folder should include unit tests for all modules that exist in the repository. You can write tests in the framework of your choice, but the Astronomer team and Airflow community typically use [pytest](https://docs.pytest.org/en/stable/).
 
 You can test this package by running: `python3 -m unittest` from the top-level of the directory.
 
-### Module Documentation
+## Part 3: Airflow Integration Standards
 
-Provider modules, including all hooks, operators, sensors, and transfers, should be documented via [sphinx-templated docstrings](https://pythonhosted.org/an_example_pypi_project/sphinx.html) at the top of each of their respective python file. These docstrings should include three things, all separated by blank lines in the docstring:
-1. A one-sentence description explaining *what* the module does.
-2. A long description explaining *how* the module works. This can include more verbose language or documentation, including code blocks or blockquotes. You can read about available Sphinx markdown directives [here](https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#directive-code-block).
-3. A declarative definition of parameters that you can pass to the module, templated per the example below.
+Airflow exposes a number of plugins to interface from your provider package. We highly encourage provider maintainers to add these plugins because they significantly improve the user experience when connecting to a provider.
 
-[See here for an active example](https://github.com/astronomer/airflow-provider-sample/blob/main/sample_provider/operators/sample_operator.py#L11).
+### Defining an entrypoint
 
-## Integrating with Airflow
-
-Airflow exposes a number of plugins to interface from your provider package in case you care to do so. We *highly* encourage provider maintainers to add these bits, as they improve the UX of a provider significantly.
-
-To start, you'll need to define an `apache_airflow_provider ` entrypoint in your `setup.py` or `setup.cfg` file:
+To enable custom connections, you first need to define an `apache_airflow_provider ` entrypoint in your `setup.py` or `setup.cfg` file:
 
 ```    
 entry_points={
@@ -122,7 +122,7 @@ entry_points={
     }
 ```
 
-Next, you'll need to add a `get_provider_info` method to [the `__init__` file in your top-level provider folder](./sample_provider/__init__.py). This function needs to return certain metadata associated with your package in order for Airflow to be able to pick it up. We are aware it's not completely ideal to define some of this metadata in a location separate from your `setup.py` file, but Airflow needs this function at runtime for its plugins to pick up the necessary information:
+Next, you need to add a `get_provider_info` method to the `__init__` file in your top-level provider folder. This function needs to return certain metadata associated with your package in order for Airflow to use it at runtime:
 
 ```python
 def get_provider_info():
@@ -136,15 +136,15 @@ def get_provider_info():
     }
 ```
 
-Once you define the entrypoint, you can leverage Airflow's native features to expose custom connection types in the Airflow UI and additional links to relevant pages of documentation and information.
+Once you define the entrypoint, you can use native Airflow features to expose custom connection types in the Airflow UI, as well as additional links to relevant documentation.
 
-### Adding Custom Connections
+### Adding Custom Connection Forms
 
-Airflow allows for custom connection forms through discoverable hooks. Below is an example of a custom connection form for the Fivetran provider.
+Airflow enables custom connection forms through discoverable hooks. The following is an example of a custom connection form for the Fivetran provider:
 
 <img src="https://user-images.githubusercontent.com/63181127/112921463-d07b2880-90d8-11eb-871b-fc4e1c6cade9.png" width="600" />
 
-Add code to the hook class to initiate a discoverable hook and create a custom connection form. The following is an example of this code.
+Add code to the hook class to initiate a discoverable hook and create a custom connection form. The following code defines a hook and a custom connection form:
 
 ```python
 class ExampleHook(BaseHook):
@@ -197,15 +197,23 @@ class ExampleHook(BaseHook):
         }
  ```
 
-`get_connection_form_widgets()` creates extra fields using flask_appbuilder. A field created this way must be named `extra__<conn_type>__<field_name>`. A veriety of field types can be created such as text, password, boolian, intiger, etc..
+Some notes about using custom connections:
 
-`get_ui_field_behaviour()` is a JSON schema describing the form field behavior. Fields can be hidden, relabeled, and be given placeholders.
+- `get_connection_form_widgets()` creates extra fields using flask_appbuilder. Extra fields are defined in the following format:
 
-Add the hook class name of a discoverable hook to `"hook-class-names"` in the `get_provider_info` method mentioned above.
- 
-### Adding Extra Links
+   ```
+   extra__<conn_type>__<field_name>
+   ```
 
-Operators can have extra links that users can use to reach an external source from the Airflow UI when interacting with an operator. This link can be created dynamically based on the context of the operator. The following code example shows how to initiate an extra link within an operator.
+   A variety of field types can be created using this function, such as strings, passwords, booleans, and integers.
+
+- `get_ui_field_behaviour()` is a JSON schema describing the form field behavior. Fields can be hidden, relabeled, and given placeholder values.
+
+- To connect a form to Airflow, add the hook class name of a discoverable hook to `"hook-class-names"` in the `get_provider_info` method as mentioned in `Defining an entrypoint`.
+
+### Adding Custom Links
+
+Operators can add custom links that users can click to reach an external source when interacting with an operator in the Airflow UI. This link can be created dynamically based on the context of the operator. The following code example shows how to initiate an extra link within an operator:
 
 ```python
 class ExampleLink(BaseOperatorLink):
@@ -225,27 +233,49 @@ class ExampleOperator(BaseOperator):
     operator_extra_links = (Example Link(),)
 ```
 
-Add the operator class name to `"extra-links"` in the `get_provider_info` method mentioned above to initiate the extra link.
+To connect custom links to Airflow, add the operator class name to `"extra-links"` in the `get_provider_info` method mentioned above.
 
-## Testing Your Package
+## Part 4: Documentation Standards
+
+Creating excellent documentation is essential for explaining the purpose of your provider package and how to use it.
+
+### Inline Module Documentation
+
+Every Python module, including all hooks, operators, sensors, and transfers, should be documented inline via [sphinx-templated docstrings](https://pythonhosted.org/an_example_pypi_project/sphinx.html). These docstrings should be included at the top of each module file and contain three sections separated by blank lines:
+- A one-sentence description explaining what the module does.
+- A longer description explaining how the module works. This can include details such as code blocks or blockquotes. For more information Sphinx markdown directives, read the [Sphinx documentation](https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#directive-code-block).
+- A declarative definition of parameters that you can pass to the module, templated per the example below.
+
+For a full example of inline module documentation, see the [example operator in this repository](https://github.com/astronomer/airflow-provider-sample/blob/main/sample_provider/operators/sample_operator.py#L11).
+
+### README
+
+The README for your provider package should give users an overview of what your provider package does. Specifically, it should include:
+
+- High-level documentation about the provider's service.
+- Steps for building a connection to the service from Airflow.
+- What modules exist within the package.
+- An exact set of dependencies and versions that your provider has been tested with.
+- Guidance for contributing to the provider package.
+
+## Part 5: Functional Testing Standards
 
 To build your repo into a python wheel that can be tested, follow the steps below:
 
-1. Clone the provider repo
-2. cd into provider directory
-3. Run `python3 -m pip install build`
-4. Run `python3 -m build` to build the wheel
-5. Find the .whl file in `/dist/*.whl`
+1. Clone the provider repo.
+2. cd into provider directory.
+3. Run `python3 -m pip install build`.
+4. Run `python3 -m build` to build the wheel.
+5. Find the .whl file in `/dist/*.whl`.
 6. Download the [Astro CLI](https://github.com/astronomer/astro-cli)
-7. Create a new project directory, cd into it, and run `astro dev init` to initialize a new astro project
+7. Create a new project directory, cd into it, and run `astro dev init` to initialize a new astro project.
 8. Ensure the Dockerfile contains Airflow 2.0: `FROM quay.io/astronomer/ap-airflow:2.0.0-buster-onbuild`
-9. Copy `.whl` file to the top-level of your Astro project
+9. Copy the `.whl` file to the top level of your project directory.
 10. Add the `.whl` file to the Dockerfile: `RUN pip install --user airflow_provider_<PROVIDER_NAME>-0.0.1-py3-none-any.whl` to install the wheel into the containerized operating environment.
 11. Copy your sample DAG to the `dags/` folder of your astro project directory.
 12. Run `astro dev start` to build the containers and run Airflow locally (you'll need Docker on your machine).
-13. When you're done, run `astro dev stop` to wind down the deployment. Run `astro dev kill` to kill the containers and remove the local Docker volumes- use this command if you need to rebuild the environment with a new `.whl` file.
+13. When you're done, run `astro dev stop` to wind down the deployment. Run `astro dev kill` to kill the containers and remove the local Docker volume. You can also use `astro dev kill` to stop the environment before rebuilding with a new `.whl` file.
 
 > Note: If you are having trouble accessing the Airflow webserver locally, there could be a bug in your wheel setup. To debug, run `docker ps`, grab the container ID of the scheduler, and run `docker logs <scheduler-container-id>` to inspect the logs.
 
-Once you have the local wheel built and tested, you're ready to [send us your repo](https://registry.astronomer.io/publish-provider) to be published on [The Astronomer Registry](https://registry.astronomer.io).
-
+Once you have built and tested your provider package as a Python wheel, you're ready to [send us your repo](https://registry.astronomer.io/publish-provider) to be published on [The Astronomer Registry](https://registry.astronomer.io).

--- a/README.md
+++ b/README.md
@@ -16,6 +16,14 @@ This repository provides best practices for building, structuring, and deploying
 
 Provider repositories must be public on Github and follow the structural and technical guidelines laid out in this Readme. Ensure that all of these requirements have been met before submitting a provider package for community review.
 
+Here, you'll find information on requirements and best practices for key aspects of your project:
+
+- [File formatting](#part-1-formatting-standards)
+- [Development](#part-2-development-standards)
+- [Airflow integration](#part-3-airflow-integration-standards)
+- [Documentation](#part-4-documentation-standards)
+- [Testing](#part-5-functional-testing)
+
 ## Part 1: Formatting Standards
 
 Before writing and testing the functionality of your provider package, ensure that your project follows these formatting conventions.
@@ -263,15 +271,25 @@ The README for your provider package should give users an overview of what your 
 To build your repo into a python wheel that can be tested, follow the steps below:
 
 1. Clone the provider repo.
-2. cd into provider directory.
+2. `cd` into provider directory.
 3. Run `python3 -m pip install build`.
 4. Run `python3 -m build` to build the wheel.
 5. Find the .whl file in `/dist/*.whl`.
-6. Download the [Astro CLI](https://github.com/astronomer/astro-cli)
+6. Download the [Astro CLI](https://github.com/astronomer/astro-cli).
 7. Create a new project directory, cd into it, and run `astro dev init` to initialize a new astro project.
-8. Ensure the Dockerfile contains Airflow 2.0: `FROM quay.io/astronomer/ap-airflow:2.0.0-buster-onbuild`
+8. Ensure the Dockerfile contains the Airflow 2.0 image:
+
+   ```
+   FROM quay.io/astronomer/ap-airflow:2.0.0-buster-onbuild`
+   ```
+
 9. Copy the `.whl` file to the top level of your project directory.
-10. Add the `.whl` file to the Dockerfile: `RUN pip install --user airflow_provider_<PROVIDER_NAME>-0.0.1-py3-none-any.whl` to install the wheel into the containerized operating environment.
+10. Install `.whl` in your containerized environment by adding the following to your Dockerfile:
+
+   ```
+   RUN pip install --user airflow_provider_<PROVIDER_NAME>-0.0.1-py3-none-any.whl`
+   ```
+
 11. Copy your sample DAG to the `dags/` folder of your astro project directory.
 12. Run `astro dev start` to build the containers and run Airflow locally (you'll need Docker on your machine).
 13. When you're done, run `astro dev stop` to wind down the deployment. Run `astro dev kill` to kill the containers and remove the local Docker volume. You can also use `astro dev kill` to stop the environment before rebuilding with a new `.whl` file.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Here, you'll find information on requirements and best practices for key aspects
 - Documentation
 - Testing
 
-## Part 1: Formatting Standards
+## Formatting Standards
 
 Before writing and testing the functionality of your provider package, ensure that your project follows these formatting conventions.
 
@@ -72,7 +72,7 @@ All provider packages must adhere to the following file structure:
 ```
 
 
-## Part 2: Development Standards
+## Development Standards
 
 If you followed the formatting guidelines above, you're now ready to start editing files to include standard package functionality.
 
@@ -114,7 +114,7 @@ Your top-level `tests/` folder should include unit tests for all modules that ex
 
 You can test this package by running: `python3 -m unittest` from the top-level of the directory.
 
-## Part 3: Airflow Integration Standards
+## Airflow Integration Standards
 
 Airflow exposes a number of plugins to interface from your provider package. We highly encourage provider maintainers to add these plugins because they significantly improve the user experience when connecting to a provider.
 
@@ -243,7 +243,7 @@ class ExampleOperator(BaseOperator):
 
 To connect custom links to Airflow, add the operator class name to `"extra-links"` in the `get_provider_info` method mentioned above.
 
-## Part 4: Documentation Standards
+## Documentation Standards
 
 Creating excellent documentation is essential for explaining the purpose of your provider package and how to use it.
 
@@ -266,7 +266,7 @@ The README for your provider package should give users an overview of what your 
 - An exact set of dependencies and versions that your provider has been tested with.
 - Guidance for contributing to the provider package.
 
-## Part 5: Functional Testing Standards
+## Functional Testing Standards
 
 To build your repo into a python wheel that can be tested, follow the steps below:
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Modules should also take advantage of native Airflow features that allow your pr
 - Register custom connection types, which improve the user experience when connecting to your tool.
 - Include `extra-links` that link your provider back to its page on the Astronomer Registry. This provides users easy access to documentation and example DAGs.
 
-See the `Airflow Integration` section below for more information on how to build in these extra features.
+Refer to the `Airflow Integration Standards` section for more information on how to build in these extra features.
 
 ### Unit testing
 


### PR DESCRIPTION
I took a shot at restructuring the README in this repo to be more in line with our general documentation standards. This included standardizing language around certain aspects of module functionality, as well as writing recommendations and explanations in a more clear and concise manner. 

Some high level recommendations I'd suggest for a future draft:

- Be more direct about what's a requirement and what's recommended. Use language like "must" to denote the former, and "best practice", "should", or "can" to denote the latter.
- Make code samples consistent with each other. I was having a hard time finding some of the information defined in `get_provider_info()` in the other samples. 

Just for transparency's sake, I also commented in a few places where I made changes that might not be immediately apparent/ intuitive. For the most part, though, my inline changes were minor wording adjustments. 