### PR TITLE
Add standard Airflow package classifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,11 @@ Your `setup.py` file should contain all of the appropriate metadata and dependen
 
 If some of the options for building your package are variables or user-defined, you can specify a `setup.cfg` file instead.
 
+To improve discoverability of your provider package on PyPI, it is recommended to [add classifiers](https://packaging.python.org/en/latest/tutorials/packaging-projects/#configuring-metadata) to the package's metadata. The following standard classifiers should be used in addition to any others you may choose to include:
+
+- Framework :: Apache Airflow
+- Framework :: Apache Airflow :: Provider
+
 ### Managing Dependencies
 
 When building providers, these guidelines will help you avoid potential for dependency conflicts:

--- a/setup.py
+++ b/setup.py
@@ -25,5 +25,9 @@ setup(
     author='Pete DeJoy',
     author_email='pete@astronomer.io',
     url='http://astronomer.io/',
+    classifiers=[
+        "Framework :: Apache Airflow",
+        "Framework :: Apache Airflow :: Provider",
+    ],
     python_requires='~=3.7',
 )


### PR DESCRIPTION
Recently, standard package [classifiers have been made available specifically for Airflow](https://lists.apache.org/thread/948vl21hgtswlhl2t4gz5n89g270vo5v). This PR adds these classifiers to the sample and recommends these be implemented as part of the package setup.