### PR TITLE
Align naming convention of docs URL in `.astro-registry.yaml`

### DIFF
--- a/.astro-registry.yaml
+++ b/.astro-registry.yaml
@@ -9,7 +9,7 @@ package-name: airflow-provider-sample
 display-name: Sample
 # URL where users should find the documentation for the provider. This could be a link to the README,
 # an external docs site, etc.
-docs_url: https://github.com/astronomer/airflow-provider-sample/blob/main/README.md
+docs-url: https://github.com/astronomer/airflow-provider-sample/blob/main/README.md
 
 # The next sections should be organized by module type (e.g. operators, hooks, functions, decorators, etc.).
 #


### PR DESCRIPTION
The current `docs_url` key in the `.astro-registry.yaml` is not consistent with the other kebab-cased keys (i.e. `package-name` and `display-name`). For consistency, the naming convention of the config keys should be the same.