### PR TITLE
Update tests and provide test dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,9 @@ Refer to the `Airflow Integration Standards` section for more information on how
 
 Your top-level `tests/` folder should include unit tests for all modules that exist in the repository. You can write tests in the framework of your choice, but the Astronomer team and Airflow community typically use [pytest](https://docs.pytest.org/en/stable/).
 
-You can test this package by running: `python3 -m unittest` from the top-level of the directory.
+Test dependencies are available as optional dependencies. You can install them by running: `pip install -e '.[devel-tests]`
+
+You can test this package by running: `pytest` from the top-level of the directory.
 
 ## Airflow Integration Standards
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,12 @@ dependencies = [
     "apache-airflow>=2.4"
 ]
 
+[project.optional-dependencies]
+devel-tests = [
+    "pytest",
+    "requests-mock",
+]
+
 [project.urls]
 Homepage = "https://astronomer.io"
 Source = "https://github.com/astronomer/airflow-provider-sample/"

--- a/tests/hooks/test_sample_hook.py
+++ b/tests/hooks/test_sample_hook.py
@@ -10,9 +10,6 @@ Run test:
 """
 
 import logging
-import os
-import pytest
-import requests_mock
 from unittest import mock
 
 # Import Hook
@@ -29,11 +26,10 @@ class TestSampleHook():
     Test Sample Hook.
     """
 
-    @requests_mock.mock()
-    def test_post(self, m):
+    def test_post(self, requests_mock):
 
         # Mock endpoint
-        m.post('https://www.httpbin.org/', json={'data': 'mocked response'})
+        requests_mock.post('https://www.httpbin.org/', json={'data': 'mocked response'})
 
         # Instantiate hook
         hook = SampleHook(
@@ -53,11 +49,10 @@ class TestSampleHook():
         # Assert the API call returns expected mocked payload
         assert payload['data'] == 'mocked response'
 
-    @requests_mock.mock()
-    def test_get(self, m):
+    def test_get(self, requests_mock):
 
         # Mock endpoint
-        m.get('https://www.httpbin.org/', json={'data': 'mocked response'})
+        requests_mock.get('https://www.httpbin.org/', json={'data': 'mocked response'})
 
         # Instantiate hook
         hook = SampleHook(

--- a/tests/operators/test_sample_operator.py
+++ b/tests/operators/test_sample_operator.py
@@ -11,9 +11,6 @@ Run test:
 
 import json
 import logging
-import os
-import pytest
-import requests_mock
 from unittest import mock
 
 # Import Operator
@@ -30,11 +27,10 @@ class TestSampleOperator:
     Test Sample Operator.
     """
 
-    @requests_mock.mock()
-    def test_operator(self, m):
+    def test_operator(self, requests_mock):
 
         # Mock endpoint
-        m.get('https://www.httpbin.org/', json={'data': 'mocked response'})
+        requests_mock.get('https://www.httpbin.org/', json={'data': 'mocked response'})
 
         operator = SampleOperator(
             task_id='run_operator',

--- a/tests/sensors/test_sample_sensor.py
+++ b/tests/sensors/test_sample_sensor.py
@@ -10,9 +10,6 @@ Run test:
 """
 
 import logging
-import os
-import pytest
-import requests_mock
 from unittest import mock
 
 # Import Sensor
@@ -29,11 +26,10 @@ class TestSampleSensor:
     Test Sample Sensor.
     """
 
-    @requests_mock.mock()
-    def test_sensor_success(self, m):
+    def test_sensor_success(self, requests_mock):
 
         # Mock endpoint
-        m.get('https://www.httpbin.org/check_status')
+        requests_mock.get('https://www.httpbin.org/check_status')
 
         operator = SampleSensor(
             task_id='sample_sensor_check',
@@ -42,13 +38,12 @@ class TestSampleSensor:
         )
 
         # Assert poke returns True
-        self.assertTrue(operator.poke(context={}))
+        assert operator.poke(context={}) == True
 
-    @requests_mock.mock()
-    def test_sensor_fail(self, m):
+    def test_sensor_fail(self, requests_mock):
 
         # Mock endpoint
-        m.get('https://www.httpbin.org/check_status', status_code=404)
+        requests_mock.get('https://www.httpbin.org/check_status', status_code=404)
 
         operator = SampleSensor(
             task_id='sample_sensor_check',
@@ -57,7 +52,7 @@ class TestSampleSensor:
         )
 
         # Assert poke returns False when endpoint returns 404
-        self.assertFalse(operator.poke(context={}))
+        assert operator.poke(context={}) == False
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I wasn't able to run the unit tests using `python3 -m unittest` as documented. Since it also mentioned pytest I added that as an optional dependency.

Even using pytest I ran into an error similar to the one on https://stackoverflow.com/q/59796255 which suggests that the requests-mock decorators might not be compatible with the python I'm using (Python 3.10.7), so I updated it to use the already provided `requests_mock` pytest fixture.